### PR TITLE
Needs sample: prefix for me

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # leaderboard-package-mocha
 Example of how to use mocha for package level testing (instead of TinyTest). To run the tests:
 
-`meteor test-packages --driver-package respondly:test-reporter string-reverser`
+`meteor test-packages --driver-package respondly:test-reporter sample:string-reverser`
 
 -----------------------
 


### PR DESCRIPTION
I get "package not found" when I try without the `sample:` prefix.
